### PR TITLE
Ionic add label and sentiment to cards on history page

### DIFF
--- a/src/pages/history/history.html
+++ b/src/pages/history/history.html
@@ -18,5 +18,7 @@
 
   <ion-card *ngFor="let thought of thoughts"  (click)="navigateToThought(thought.id)">
     <ion-card-header>{{ thought.attributes.title }}</ion-card-header>
+    <p> {{thought.attributes.sentiments}}</p>
+    <p> {{thought.attributes.labels}}</p>
   </ion-card>
 </ion-content>


### PR DESCRIPTION
### PT-Link: https://www.pivotaltracker.com/story/show/154841834
### Description:
Adds label and sentiment to thought cards on history page