### PR TITLE
Ionic add tag count to sentiment and label index pages

### DIFF
--- a/src/pages/labels-index/labels-index.html
+++ b/src/pages/labels-index/labels-index.html
@@ -10,6 +10,6 @@
 
 <ion-content padding>
   <ion-card *ngFor="let label of labels" (click)="navigateToLabel(label.id, label.name)">
-    <ion-card-header> {{ label.name }} </ion-card-header>
+    <ion-card-header> {{ label.name }} ({{label.taggings_count}}) </ion-card-header>
   </ion-card>
 </ion-content>

--- a/src/pages/sentiments-index/sentiments-index.html
+++ b/src/pages/sentiments-index/sentiments-index.html
@@ -12,6 +12,6 @@
 
 <ion-content padding>
   <ion-card *ngFor="let sentiment of sentiments" (click)="navigateToSentiment(sentiment.id, sentiment.name)">
-    <ion-card-header>{{ sentiment.name }}</ion-card-header>
+    <ion-card-header>{{ sentiment.name }} ({{sentiment.taggings_count}})</ion-card-header>
   </ion-card>
 </ion-content>


### PR DESCRIPTION
### PT-Link: https://www.pivotaltracker.com/story/show/154704919
### Description:
Adds count of thoughts to cards of labels and sentiments